### PR TITLE
Nextjs: navigator not defined

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -43,7 +43,8 @@ export class EnablementFailedError extends Error {
 }
 
 export const checkIsMobile = () =>
-  /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+  typeof navigator === "undefined" ? false :
+    /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
     navigator.userAgent
   );
 


### PR DESCRIPTION
When using Nextjs framework(server side rendering), the object `navigator` does not exist, as its not in the client yet.

`ReferenceError: navigator is not defined`

`navigator` used in: https://github.com/cardano-foundation/cardano-connect-with-wallet/blob/main/src/utils/common.ts#L45
